### PR TITLE
Use variable width for currency selection

### DIFF
--- a/app/src/containers/WalletHome.vue
+++ b/app/src/containers/WalletHome.vue
@@ -228,10 +228,10 @@ export default {
 .wallet-home {
   ::v-deep .currency-selector {
     @include navSelector();
-    max-width: 50px;
+    max-width: 100px;
     .v-select__selection {
       color: var(--v-primary-base) !important;
-      width: 25px;
+      width: 1vw;
     }
   }
 


### PR DESCRIPTION
Fix for currency display width in Firefox. Fix works on both Firefox and Chromium based browsers.