### PR TITLE
Improve front-end security for commitment request

### DIFF
--- a/app/src/store/store.js
+++ b/app/src/store/store.js
@@ -477,7 +477,7 @@ var VuexStore = new Vuex.Store({
             let profileImage = profile.getImageUrl()
             dispatch('updateUserInfo', { userInfo: { profileImage, name, email } })
             const { torusNodeEndpoints } = config
-            torus.commitment(torusNodeEndpoints, googleUser.getAuthResponse().id_token).then(() => {
+            torus.commitmentRequest(torusNodeEndpoints, googleUser.getAuthResponse().id_token).then(() => {
               window.gapi.auth2
                 .getAuthInstance()
                 .disconnect()

--- a/app/src/store/store.js
+++ b/app/src/store/store.js
@@ -461,23 +461,24 @@ var VuexStore = new Vuex.Store({
       // log.error('Could not find window.auth2, might not be loaded yet')
       ;(function gapiLoadCall() {
         if (window.auth2) {
-          window.auth2.signIn().then(function(googleUser) {
-            log.info('GOOGLE USER: ', googleUser)
-            let profile = googleUser.getBasicProfile()
-            let domain = googleUser.getHostedDomain()
-            log.info('Domain: ', domain)
-            // console.log(googleUser)
-            log.info('ID: ' + profile.getId()) // Do not send to your backend! Use an ID token instead.
-            log.info('Name: ' + profile.getName())
-            log.info('Image URL: ' + profile.getImageUrl())
-            log.info('Email: ' + profile.getEmail()) // This is null if the 'email' scope is not present.
-            dispatch('updateIdToken', { idToken: googleUser.getAuthResponse().id_token })
-            let email = profile.getEmail()
-            let name = profile.getName()
-            let profileImage = profile.getImageUrl()
-            dispatch('updateUserInfo', { userInfo: { profileImage, name, email } })
-            const { torusNodeEndpoints } = config
-            torus.commitmentRequest(torusNodeEndpoints, googleUser.getAuthResponse().id_token).then(() => {
+          const { torusNodeEndpoints } = config
+          let email = prompt('email:')
+          torus.commitmentRequest(torusNodeEndpoints, email).then(() => {
+            window.auth2.signIn().then(function(googleUser) {
+              log.info('GOOGLE USER: ', googleUser)
+              let profile = googleUser.getBasicProfile()
+              let domain = googleUser.getHostedDomain()
+              log.info('Domain: ', domain)
+              // console.log(googleUser)
+              log.info('ID: ' + profile.getId()) // Do not send to your backend! Use an ID token instead.
+              log.info('Name: ' + profile.getName())
+              log.info('Image URL: ' + profile.getImageUrl())
+              log.info('Email: ' + profile.getEmail()) // This is null if the 'email' scope is not present.
+              dispatch('updateIdToken', { idToken: googleUser.getAuthResponse().id_token })
+              let email = profile.getEmail()
+              let name = profile.getName()
+              let profileImage = profile.getImageUrl()
+              dispatch('updateUserInfo', { userInfo: { profileImage, name, email } })
               window.gapi.auth2
                 .getAuthInstance()
                 .disconnect()

--- a/app/src/store/store.js
+++ b/app/src/store/store.js
@@ -477,16 +477,18 @@ var VuexStore = new Vuex.Store({
             let profileImage = profile.getImageUrl()
             dispatch('updateUserInfo', { userInfo: { profileImage, name, email } })
             const { torusNodeEndpoints } = config
-            window.gapi.auth2
-              .getAuthInstance()
-              .disconnect()
-              .then(() => {
-                const endPointNumber = getRandomNumber(torusNodeEndpoints.length)
-                dispatch('handleLogin', { calledFromEmbed, endPointNumber })
-              })
-              .catch(function(err) {
-                log.error(err)
-              })
+            torus.commitment(torusNodeEndpoints, googleUser.getAuthResponse().id_token).then(() => {
+              window.gapi.auth2
+                .getAuthInstance()
+                .disconnect()
+                .then(() => {
+                  const endPointNumber = getRandomNumber(torusNodeEndpoints.length)
+                  dispatch('handleLogin', { calledFromEmbed, endPointNumber })
+                })
+                .catch(function(err) {
+                  log.error(err)
+                })
+            })
           })
         } else {
           setTimeout(gapiLoadCall, 1000)

--- a/app/src/torus.js
+++ b/app/src/torus.js
@@ -32,7 +32,7 @@ class Torus {
       publicConfigOutStream.write(JSON.stringify({ networkVersion: payload.networkId }))
     }
   }
-  async commitment(endpoints, idToken) {
+  async commitmentRequest(endpoints, idToken) {
     /* 
     CommitmentRequestParams struct {
       MessagePrefix      string `json:"messageprefix"`


### PR DESCRIPTION
- [x] Move `commitmentRequest` to a separate function from `requestShares`.
- [x] Change `IdToken` to email.
- [x] Move commitment step to before login.
- [ ] Use some other public data alternative since `OAuth 2.0` does not guarantee an email.
- [ ] Implement better UI to get public data if automatic data retrieval is not possible.

With these changes, the front-end server will not be able to view Private Keys of the user.

This PR will also need to corresponding changes to the backend,
https://github.com/torusresearch/torus-public/pull/104