### PR TITLE
Fix total cost not showing

### DIFF
--- a/app/src/containers/WalletTransfer/WalletTransfer.vue
+++ b/app/src/containers/WalletTransfer/WalletTransfer.vue
@@ -407,7 +407,7 @@ export default {
       }
     },
     updateTotalCost() {
-      if (!this.displayAmount || this.speedSelected === '') {
+      if (!this.displayAmount || this.activeGasPrice === '') {
         this.totalCost = ''
         this.convertedTotalCost = ''
         return
@@ -442,6 +442,7 @@ export default {
       this.gas = data.gas
 
       if (data.isReset) {
+        this.activeGasPrice = this.speedSelected === '' ? '' : this.activeGasPrice
         this.calculateGas()
       }
       this.updateTotalCost()


### PR DESCRIPTION
When user uses advanced options without selecting a transaction speed first
- Fix total cost not showing 
- Fix "Reset" not to select any speed option when no initial option is selected in the first place 