### PR TITLE
Fix problems with USDC

### DIFF
--- a/app/src/containers/WalletTopup/WalletTopupRampNetwork/WalletTopupRampNetwork.vue
+++ b/app/src/containers/WalletTopup/WalletTopupRampNetwork/WalletTopupRampNetwork.vue
@@ -45,7 +45,7 @@ export default {
             self.cryptoCurrencySymbol = asset.symbol
             self.currencyRate = 1 / asset.price[payload.selectedCurrency]
             self.currentOrder = {
-              cryptoCurrencyValue: cryptoValue * 10 ** asset.decimals,
+              cryptoCurrencyValue: Math.trunc(cryptoValue * 10 ** asset.decimals),
               cryptoCurrencySymbol: asset.symbol,
             }
           })


### PR DESCRIPTION
When buying USDC the integration code is passing float numbers to Ramp Instant widget, the amount should always be integer value