### PR TITLE
Prioritize error params of redirect/ from auth0

### DIFF
--- a/app/src/utils/utils.js
+++ b/app/src/utils/utils.js
@@ -622,7 +622,7 @@ export const handleRedirectParameters = (hash, queryParameters) => {
   if (!queryParameters.preopenInstanceId) {
     if (Object.keys(hashParameters).length > 0 && hashParameters.state) {
       instanceParameters = JSON.parse(atob(decodeURIComponent(decodeURIComponent(hashParameters.state)))) || {}
-      if (hashParameters.error) error = hashParameters.error
+      error = hashParameters.error_description || hashParameters.error || error
     } else if (Object.keys(queryParameters).length > 0 && queryParameters.state) {
       instanceParameters = JSON.parse(atob(decodeURIComponent(decodeURIComponent(queryParameters.state)))) || {}
       if (queryParameters.error) error = queryParameters.error


### PR DESCRIPTION
**Background**
When `Force email verification` is set under Rules in Auth0, access denied error is returned with the redirect URL as the following format. 

```
https://yourapp.com/callback?error=unauthorized&error_description=Access%20to%20this%20application%20has%20been%20temporarily%20revoked
```
See: https://auth0.com/docs/rules/references/samples#deny-access-based-on-a-condition

It eventually returns callback to frontend as following as far as I've checked. 
```
https://lrc.tor.us/redirect#error=unauthorized&error_description=Please%20verify%20your%20email%20before%20logging%20in.&state=...
```

**Issue**
Although Torus-website handles this error message and emits `error=unauthorized`, only the message `unauthorized` does not allow frontend distinguish it coming from Auth0. Hopefully client side wants to display the particular message which tell endusers check email verification in case of Auth0 etc. 


**Solution**
`error_description` key value should be returned instead of `error ` since it has more details and managed by Auth0 admin user.

**Note**
I could not see fully of how everything is connected in torus multiple applications with the combination of Auth0.
Especially not 100% sure it is `hashParameters` or `queryParameters` and how it is replaced from queryParameters...