### PR TITLE
Improve Sentry and loglevel integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1577,14 +1577,62 @@
       }
     },
     "@sentry/browser": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.0.1.tgz",
-      "integrity": "sha512-iP8Bqxj4Ye8CXA4ja77buPZfXsKiZYUgHFzBQxVMihTHA8ZZLgBMPLQI6uFfHuJJW+1/yLzOf8BhvF2zknAebg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.0.2.tgz",
+      "integrity": "sha512-Vkww+P7qYhhYp4+elYQ2UjbDNFzOLC0tWaegjA6ohXHewiCWio5byySLxPAwj2gfLIXwIuf5Ud21njZHg7FSIQ==",
       "requires": {
-        "@sentry/core": "6.0.1",
-        "@sentry/types": "6.0.1",
-        "@sentry/utils": "6.0.1",
+        "@sentry/core": "6.0.2",
+        "@sentry/types": "6.0.2",
+        "@sentry/utils": "6.0.2",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.0.2.tgz",
+          "integrity": "sha512-7v9tiHRYxDT1WxVNQJc+K4s9T2m++0I+ERrTx4fx5vRzTZrtS9nDjpbiLGonGZaV6Lv2houZUp4uLVNU3vtOQw==",
+          "requires": {
+            "@sentry/hub": "6.0.2",
+            "@sentry/minimal": "6.0.2",
+            "@sentry/types": "6.0.2",
+            "@sentry/utils": "6.0.2",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.0.2.tgz",
+          "integrity": "sha512-/rByl+ak5Ni6xTSfzIcJqKaaErJbDw0kXgNlHGPRQ4bM5hjDDuKbdykMk4J6BfPWt2dfwe13P25bIjz9M3a7kw==",
+          "requires": {
+            "@sentry/types": "6.0.2",
+            "@sentry/utils": "6.0.2",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.0.2.tgz",
+          "integrity": "sha512-wrSTTIvDsRCXbNcfha/fjkP7Mj1xzNHzGeBRMRlNg3T+nYZSrs5SihVTXT/gcABhO5PpWu8EXbMpv0bAahaEGw==",
+          "requires": {
+            "@sentry/hub": "6.0.2",
+            "@sentry/types": "6.0.2",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.0.2.tgz",
+          "integrity": "sha512-aDUJuOe0MsqjDzx6dUTS6xXe+gNjYuZTHUuUB7EpihzoHGre7gUN3/WCCghiR4OJ703fxyl24cex6vDboZJLvg=="
+        },
+        "@sentry/utils": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.0.2.tgz",
+          "integrity": "sha512-X2hAFMkfht4GzdtqrjuVJfK07af5r6h2BfYJGSS/XYa8KBVlDGAtvffP9uYuNWUoLxr+Vrc+ePrPoi4xCREcDQ==",
+          "requires": {
+            "@sentry/types": "6.0.2",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/cli": {
@@ -1693,6 +1741,19 @@
         "@sentry/types": "6.0.1",
         "@sentry/utils": "6.0.1",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/browser": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.0.1.tgz",
+          "integrity": "sha512-iP8Bqxj4Ye8CXA4ja77buPZfXsKiZYUgHFzBQxVMihTHA8ZZLgBMPLQI6uFfHuJJW+1/yLzOf8BhvF2zknAebg==",
+          "requires": {
+            "@sentry/core": "6.0.1",
+            "@sentry/types": "6.0.1",
+            "@sentry/utils": "6.0.1",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sindresorhus/is": {
@@ -1978,6 +2039,16 @@
       "integrity": "sha512-Bg9AE3lPaPCv9OQAFusQlCE5TxxJCuT3R9ilGMhDiOfWQdtdW0f+cfzoRSQGA1I/lq0V217MNvWeJNLejLdsSA==",
       "requires": {
         "deepmerge": "^4.2.2"
+      }
+    },
+    "@toruslabs/loglevel-sentry": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@toruslabs/loglevel-sentry/-/loglevel-sentry-2.2.1.tgz",
+      "integrity": "sha512-ohP9HouxrlDGu2irOZx1gt6pb4RMFoVE5rq6t3pioGKXYUz4pce/BTaXHasj7SVR/e1Om9hcngb6dIAMIaAmyg==",
+      "requires": {
+        "@sentry/core": "^6.0.1",
+        "@sentry/types": "^6.0.1",
+        "loglevel": "^1.7.1"
       }
     },
     "@toruslabs/torus-direct-web-sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2042,9 +2042,9 @@
       }
     },
     "@toruslabs/loglevel-sentry": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@toruslabs/loglevel-sentry/-/loglevel-sentry-2.2.1.tgz",
-      "integrity": "sha512-ohP9HouxrlDGu2irOZx1gt6pb4RMFoVE5rq6t3pioGKXYUz4pce/BTaXHasj7SVR/e1Om9hcngb6dIAMIaAmyg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/loglevel-sentry/-/loglevel-sentry-2.3.0.tgz",
+      "integrity": "sha512-44tPyGvAI4TYkCx/q3tARNzfii5KlgBeBuEVn8WlS+sA4r/HgfmpAQ7ibWWjJKiJ9iBBJyON4j2nyFOAufVTWw==",
       "requires": {
         "@sentry/core": "^6.0.1",
         "@sentry/types": "^6.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1731,26 +1731,61 @@
       }
     },
     "@sentry/vue": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-6.0.1.tgz",
-      "integrity": "sha512-gcOYga8VgCqOmUr6alUMtnRjGvke8i//hEXGOoA+7WXDXunikwsuSq13K0agwT/KWtO9MBB0tNUKs87ejgvX1A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-6.0.2.tgz",
+      "integrity": "sha512-FIMvGBFH0PSLZ1usgDPr+TbhyLWhB5xMK3heWC+ClD/MyyX9v7LRndK/FtRifLBRkC9Hl2+xKgI0MnKwbh/rWw==",
       "requires": {
-        "@sentry/browser": "6.0.1",
-        "@sentry/core": "6.0.1",
-        "@sentry/minimal": "6.0.1",
-        "@sentry/types": "6.0.1",
-        "@sentry/utils": "6.0.1",
+        "@sentry/browser": "6.0.2",
+        "@sentry/core": "6.0.2",
+        "@sentry/minimal": "6.0.2",
+        "@sentry/types": "6.0.2",
+        "@sentry/utils": "6.0.2",
         "tslib": "^1.9.3"
       },
       "dependencies": {
-        "@sentry/browser": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.0.1.tgz",
-          "integrity": "sha512-iP8Bqxj4Ye8CXA4ja77buPZfXsKiZYUgHFzBQxVMihTHA8ZZLgBMPLQI6uFfHuJJW+1/yLzOf8BhvF2zknAebg==",
+        "@sentry/core": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.0.2.tgz",
+          "integrity": "sha512-7v9tiHRYxDT1WxVNQJc+K4s9T2m++0I+ERrTx4fx5vRzTZrtS9nDjpbiLGonGZaV6Lv2houZUp4uLVNU3vtOQw==",
           "requires": {
-            "@sentry/core": "6.0.1",
-            "@sentry/types": "6.0.1",
-            "@sentry/utils": "6.0.1",
+            "@sentry/hub": "6.0.2",
+            "@sentry/minimal": "6.0.2",
+            "@sentry/types": "6.0.2",
+            "@sentry/utils": "6.0.2",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.0.2.tgz",
+          "integrity": "sha512-/rByl+ak5Ni6xTSfzIcJqKaaErJbDw0kXgNlHGPRQ4bM5hjDDuKbdykMk4J6BfPWt2dfwe13P25bIjz9M3a7kw==",
+          "requires": {
+            "@sentry/types": "6.0.2",
+            "@sentry/utils": "6.0.2",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.0.2.tgz",
+          "integrity": "sha512-wrSTTIvDsRCXbNcfha/fjkP7Mj1xzNHzGeBRMRlNg3T+nYZSrs5SihVTXT/gcABhO5PpWu8EXbMpv0bAahaEGw==",
+          "requires": {
+            "@sentry/hub": "6.0.2",
+            "@sentry/types": "6.0.2",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.0.2.tgz",
+          "integrity": "sha512-aDUJuOe0MsqjDzx6dUTS6xXe+gNjYuZTHUuUB7EpihzoHGre7gUN3/WCCghiR4OJ703fxyl24cex6vDboZJLvg=="
+        },
+        "@sentry/utils": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.0.2.tgz",
+          "integrity": "sha512-X2hAFMkfht4GzdtqrjuVJfK07af5r6h2BfYJGSS/XYa8KBVlDGAtvffP9uYuNWUoLxr+Vrc+ePrPoi4xCREcDQ==",
+          "requires": {
+            "@sentry/types": "6.0.2",
             "tslib": "^1.9.3"
           }
         }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@chaitanyapotti/random-id": "^1.0.3",
     "@metamask/contract-metadata": "^1.21.0",
+    "@sentry/browser": "^6.0.2",
     "@sentry/vue": "^6.0.1",
     "@tkey/core": "^3.8.1",
     "@tkey/security-questions": "^3.8.0",
@@ -40,6 +41,7 @@
     "@tkey/web-storage": "^3.8.1",
     "@toruslabs/fetch-node-details": "^2.3.4",
     "@toruslabs/http-helpers": "^1.3.5",
+    "@toruslabs/loglevel-sentry": "^2.2.1",
     "@toruslabs/torus.js": "^2.2.15",
     "@unstoppabledomains/resolution": "^1.17.0",
     "@walletconnect/core": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@tkey/web-storage": "^3.8.1",
     "@toruslabs/fetch-node-details": "^2.3.4",
     "@toruslabs/http-helpers": "^1.3.5",
-    "@toruslabs/loglevel-sentry": "^2.2.1",
+    "@toruslabs/loglevel-sentry": "^2.3.0",
     "@toruslabs/torus.js": "^2.2.15",
     "@unstoppabledomains/resolution": "^1.17.0",
     "@walletconnect/core": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@chaitanyapotti/random-id": "^1.0.3",
     "@metamask/contract-metadata": "^1.21.0",
     "@sentry/browser": "^6.0.2",
-    "@sentry/vue": "^6.0.1",
+    "@sentry/vue": "^6.0.2",
     "@tkey/core": "^3.8.1",
     "@tkey/security-questions": "^3.8.0",
     "@tkey/seed-phrase": "^3.8.0",

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -3,6 +3,14 @@ import * as Sentry from '@sentry/vue'
 import LoglevelSentryPlugin from '@toruslabs/loglevel-sentry'
 import log from 'loglevel'
 
+function getSampleRate() {
+  try {
+    return Math.parseFloat(process.env.VUE_APP_SENTRY_SAMPLE_RATE)
+  } catch {
+    return 0.2
+  }
+}
+
 export function installSentry(Vue) {
   if (!process.env.VUE_APP_SENTRY_DSN) return
 
@@ -13,7 +21,7 @@ export function installSentry(Vue) {
     release: `torus-website@${process.env.VUE_APP_TORUS_BUILD_VERSION}`,
     autoSessionTracking: true,
     integrations: [new Integrations.Breadcrumbs({ console: false })],
-    sampleRate: 1,
+    sampleRate: getSampleRate(),
   })
 
   const plugin = new LoglevelSentryPlugin(Sentry)

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -5,7 +5,7 @@ import log from 'loglevel'
 
 function getSampleRate() {
   try {
-    return Math.parseFloat(process.env.VUE_APP_SENTRY_SAMPLE_RATE)
+    return Number.parseFloat(process.env.VUE_APP_SENTRY_SAMPLE_RATE)
   } catch {
     return 0.2
   }


### PR DESCRIPTION
This uses `@toruslabs/loglevel-sentry` to improve Sentry-loglevel integration as well as remove boilerplate code.