### PR TITLE
Fixes for ramp api n/w

### DIFF
--- a/src/store/PaymentActions/rampnetwork.js
+++ b/src/store/PaymentActions/rampnetwork.js
@@ -8,7 +8,7 @@ export default {
   fetchRampNetworkQuote(_, payload) {
     // returns a promise
     return postQuote({
-      cryptoAssetSymbol: (payload.selectedCryptoCurrency || ETH).toLowerCase(),
+      cryptoAssetSymbol: (payload.selectedCryptoCurrency || ETH).toUpperCase(),
       fiatCurrency: (payload.selectedCurrency || paymentProviders.rampnetwork.validCurrencies[0]).toLowerCase(),
       fiatValue: +Number.parseFloat(payload.fiatValue || paymentProviders.rampnetwork.minOrderValue),
       paymentMethodType: 'CARD_PAYMENT',


### PR DESCRIPTION
Ramp API Network was not able to fetch prices for `DAI`, `BNB`, and `USDC`. The error was because of sending these tokens in `lowercase`.

**BEFORE**

<img width="861" alt="image" src="https://user-images.githubusercontent.com/29117472/173292153-0d86ba01-4e9f-4150-9221-f3c5f39101c6.png">


**AFTER**

<img width="861" alt="image" src="https://user-images.githubusercontent.com/29117472/173292096-73200ba4-b633-4f0f-930c-029c7a6df72a.png">
