### PR TITLE
Fetch payment providers based on chainId for topup

### DIFF
--- a/src/components/WalletTopup/PlaceholderTopupProviders/PlaceholderTopupProviders.vue
+++ b/src/components/WalletTopup/PlaceholderTopupProviders/PlaceholderTopupProviders.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script>
-import { MAINNET } from '../../../utils/enums'
+import { MAINNET, MAINNET_CODE } from '../../../utils/enums'
 import { getPaymentProviders } from '../../../utils/utils'
 import WriteToUs from '../WriteToUs'
 
@@ -47,7 +47,7 @@ export default {
   components: { WriteToUs },
   data() {
     return {
-      providers: getPaymentProviders(MAINNET),
+      providers: getPaymentProviders(MAINNET_CODE),
     }
   },
   methods: {

--- a/src/containers/WalletTopup/WalletTopupHome/WalletTopupHome.vue
+++ b/src/containers/WalletTopup/WalletTopupHome/WalletTopupHome.vue
@@ -75,13 +75,12 @@ export default {
     }
   },
   computed: {
-    ...mapState(['theme', 'whiteLabel', 'networkType']),
+    ...mapState(['theme', 'whiteLabel', 'networkType', 'networkId']),
     providers() {
-      const network = this.networkType.host
       if (this.whiteLabel.isActive) {
-        return getPaymentProviders(network, this.whiteLabel.theme.isDark ? THEME_DARK_BLACK_NAME : THEME_LIGHT_BLUE_NAME)
+        return getPaymentProviders(this.networkId, this.whiteLabel.theme.isDark ? THEME_DARK_BLACK_NAME : THEME_LIGHT_BLUE_NAME)
       }
-      return getPaymentProviders(network, this.theme)
+      return getPaymentProviders(this.networkId, this.theme)
     },
     noSupportedProvidersForNetwork() {
       return this.providers.length === 0

--- a/src/controllers/network/createInfuraClient.js
+++ b/src/controllers/network/createInfuraClient.js
@@ -11,7 +11,7 @@ import {
 } from 'eth-json-rpc-middleware'
 
 import config from '../../config'
-import { NETWORK_TYPE_TO_ID_MAP } from '../../utils/enums'
+import { INFURA_NETWORK_TYPE_TO_ID_MAP } from '../../utils/enums'
 
 export function createInfuraClient({ network }) {
   const infuraMiddleware = createInfuraMiddleware({ network, projectId: config.infuraKey })
@@ -31,10 +31,10 @@ export function createInfuraClient({ network }) {
 }
 
 export function createNetworkAndChainIdMiddleware({ network }) {
-  if (!NETWORK_TYPE_TO_ID_MAP[network.toString()]) {
+  if (!INFURA_NETWORK_TYPE_TO_ID_MAP[network.toString()]) {
     throw new Error(`createInfuraClient - unknown network "${network}"`)
   }
-  const { chainId, networkId } = NETWORK_TYPE_TO_ID_MAP[network]
+  const { chainId, networkId } = INFURA_NETWORK_TYPE_TO_ID_MAP[network]
 
   return createScaffoldMiddleware({
     eth_chainId: chainId,

--- a/src/utils/enums.js
+++ b/src/utils/enums.js
@@ -244,7 +244,8 @@ export const getInfuraBlockExplorerUrl = (network) => {
   if (network === MAINNET) return 'https://etherscan.io'
   return `https://${network}.etherscan.io`
 }
-export const NETWORK_TYPE_TO_ID_MAP = {
+
+export const INFURA_NETWORK_TYPE_TO_ID_MAP = {
   [ROPSTEN]: { networkId: ROPSTEN_CODE, chainId: ROPSTEN_CHAIN_ID },
   [RINKEBY]: { networkId: RINKEBY_CODE, chainId: RINKEBY_CHAIN_ID },
   [KOVAN]: { networkId: KOVAN_CODE, chainId: KOVAN_CHAIN_ID },

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -689,8 +689,9 @@ export const SUPPORTED_PROVIDERS_PER_NETWORK = (() => {
   return supportedProvidersPerNetwork
 })()
 
-export function getPaymentProviders(network, theme) {
-  const supportedProviders = SUPPORTED_PROVIDERS_PER_NETWORK[network] ?? []
+export function getPaymentProviders(networkId, theme) {
+  const network = Object.values(SUPPORTED_NETWORK_TYPES).find(({ chainId }) => chainId === networkId)
+  const supportedProviders = SUPPORTED_PROVIDERS_PER_NETWORK[network?.host] ?? []
   return supportedProviders.map((x) => {
     const item = paymentProviders[x]
     return {


### PR DESCRIPTION
## Ticket Link
https://toruslabs.atlassian.net/browse/PD-1101
## What does this PR do?
Users using torus embed may specify a custom network host but utilise an existing chain id that we support top up for. So we should utilise that instead of network host to show the top up providers on top up page.