### PR TITLE
Add chain under transak for eth+polygon network

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -636,6 +636,7 @@ export const paymentProviders = {
         { value: 'ETH', display: 'ETH' },
         { value: 'USDC', display: 'USDC' },
         { value: 'USDT', display: 'USDT' },
+        { value: 'CHAIN', display: 'CHAIN' },
       ],
       [MATIC]: [
         { value: 'AAVE', display: 'AAVE' },
@@ -644,6 +645,7 @@ export const paymentProviders = {
         { value: 'USDC', display: 'USDC' },
         { value: 'USDT', display: 'USDT' },
         { value: 'WETH', display: 'WETH' },
+        { value: 'CHAIN', display: 'CHAIN' },
       ],
       [BSC_MAINNET]: [
         { value: 'BNB', display: 'BNB' },


### PR DESCRIPTION
## Ticket Link
https://toruslabs.atlassian.net/browse/PD-1130

## What does this PR do?
Adds [CHAIN](https://www.cryptocompare.com/coins/chain/overview) under Transak for ethereum mainnet and polygon network