### PR TITLE
Remove supported networks from store

### DIFF
--- a/src/store/store.js
+++ b/src/store/store.js
@@ -38,7 +38,6 @@ if (config.localStorageAvailable) {
       jwtToken: state.jwtToken,
       theme: state.theme,
       locale: state.locale,
-      supportedNetworks: state.supportedNetworks,
       defaultPublicAddress: state.defaultPublicAddress,
       wcConnectorSession: state.wcConnectorSession,
     }),


### PR DESCRIPTION
We replaced `supportedNetworks` with `customNetworks` in the global store, but somehow it got added in the recent commits.