### PR TITLE
only pass email there is data

### DIFF
--- a/src/store/PaymentActions/wyre.js
+++ b/src/store/PaymentActions/wyre.js
@@ -46,7 +46,7 @@ export default {
         sourceCurrency: currentOrder.sourceCurrency,
         destCurrency: currentOrder.destCurrency,
         dest: `${network}:${selectedAddress}`,
-        email: state.userInfo.email,
+        email: state.userInfo.email || undefined,
         redirectUrl: `${config.redirect_uri}?state=${instanceState}`,
         failureRedirectUrl: `${config.redirect_uri}?state=${instanceState}`,
         referrerAccountId: config.wyreAccountId,


### PR DESCRIPTION
Issue - There are cases where email is blank when doing topup and wyre does not accept empty string for email