### PR TITLE
Rebrand RSK to Rootstock

### DIFF
--- a/src/utils/enums.js
+++ b/src/utils/enums.js
@@ -120,8 +120,8 @@ export const BSC_TESTNET_DISPLAY_NAME = 'Binance Smart Chain Testnet'
 export const OKC_MAINNET_DISPLAY_NAME = 'OKXChain Mainnet'
 export const OKC_TESTNET_DISPLAY_NAME = 'OKXChain Testnet'
 export const XDAI_DISPLAY_NAME = 'Gnosis Chain'
-export const RSK_MAINNET_DISPLAY_NAME = 'RSK Mainnet'
-export const RSK_TESTNET_DISPLAY_NAME = 'RSK Testnet'
+export const RSK_MAINNET_DISPLAY_NAME = 'Rootstock Mainnet'
+export const RSK_TESTNET_DISPLAY_NAME = 'Rootstock Testnet'
 export const REEF_DISPLAY_NAME = 'Reef Chain'
 export const ARBITRUM_MAINNET_DISPLAY_NAME = 'Arbitrum One'
 export const ARBITRUM_TESTNET_DISPLAY_NAME = 'Arbitrum Testnet'
@@ -423,7 +423,7 @@ export const SUPPORTED_NETWORK_TYPES = {
     RSK_MAINNET_CODE,
     RSK_MAINNET_BLOCK_EXPLORER,
     RSK_MAINNET_TICKER,
-    'RSK',
+    'Rootstock',
     'rsk.svg',
     RSK_MAINNET_URL
   ),
@@ -467,7 +467,7 @@ export const SUPPORTED_NETWORK_TYPES = {
     RSK_TESTNET_CODE,
     RSK_TESTNET_BLOCK_EXPLORER,
     RSK_TESTNET_TICKER,
-    'RSK Testnet',
+    'Rootstock Testnet',
     'rsk.svg',
     RSK_TESTNET_URL
   ),


### PR DESCRIPTION
This Pull request is for rebranding the publicly visible name RSK (short form) to Rootstock.

The logo for RSK is also changed. I noticed the logos are stored in Amazon S3 bucket. So, I have attached the logo here as a .svg file. Please let me know if I can upload it myself. The name of the file will remain `rsk.svg`

Thank you
![rsk](https://user-images.githubusercontent.com/25885296/209342649-3da34063-9ca9-4748-9640-9128c3c4cdb8.svg)
