### PR TITLE
Save whitelabel data when opened in embedded mode.

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -653,7 +653,7 @@ export default {
 
             if (store.appState) {
               const appStateParams = JSON.parse(safeatob(store.appState))
-              if (appStateParams?.whiteLabel) {
+              if (!isMain && appStateParams?.whiteLabel) {
                 commit('setWhiteLabel', { ...appStateParams.whiteLabel })
               }
               if (


### PR DESCRIPTION
**Issue**:- 

![image](https://user-images.githubusercontent.com/29117472/211788309-ed09d6c0-359b-4bdd-be4b-88de6afdd0fb.png)

**RCA**:-

- When we were fetching existing open login session data from the broadcast server, we were also setting the Whitelabel data if found on torus-wallet. This resulted in the setting of Whitelabel from a custom dapp, which ideally shouldn't happen.
- Bcoz of the above, if we logout from torus-wallet and relogin using a different account (ex: google login), we were seeing the existing Whitelabel data as it is never cleared from the session storage.

**Fix**:-

- Set Whitelabel data only when torus-wallet is open in the embedded mode.
